### PR TITLE
Ajustes sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.exclusions=**/*.test.js
+sonar.exclusions=**/*.test.*


### PR DESCRIPTION
Foi alterado o filtro de exclusão do sonar para que considere todos os arquivos que tenha ".test." em sua nomenclatura.